### PR TITLE
Update package references for HtmlAgilityPack, DuckDB.NET.Data.Full, DuckDB.NET.Data, and SixLabors.ImageSharp.

### DIFF
--- a/src/Data.Analysis.InteractiveExtension.Tests/Data.Analysis.InteractiveExtension.Tests.csproj
+++ b/src/Data.Analysis.InteractiveExtension.Tests/Data.Analysis.InteractiveExtension.Tests.csproj
@@ -11,7 +11,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.9.0" />
 		<PackageReference Include="Assent" Version="2.1.0" />
-		<PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
+		<PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 		<PackageReference Include="Microsoft.DotNet.Interactive" Version="1.0.0-beta.24164.1" />
 		<PackageReference Include="Microsoft.DotNet.Interactive.CSharp" Version="1.0.0-beta.24164.1" />

--- a/src/DuckDB.InteractiveExtension.Tests/DuckDB.InteractiveExtension.Tests.csproj
+++ b/src/DuckDB.InteractiveExtension.Tests/DuckDB.InteractiveExtension.Tests.csproj
@@ -11,7 +11,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.9.0" />
 		<PackageReference Include="Assent" Version="2.1.0" />
-		<PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
+		<PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 		<PackageReference Include="Microsoft.DotNet.Interactive" Version="1.0.0-beta.24164.1" />
 		<PackageReference Include="Microsoft.DotNet.Interactive.CSharp" Version="1.0.0-beta.24164.1" />

--- a/src/DuckDB.InteractiveExtension/DuckDB.InteractiveExtension.csproj
+++ b/src/DuckDB.InteractiveExtension/DuckDB.InteractiveExtension.csproj
@@ -23,8 +23,8 @@
 	<!-- sanddance resources -->
 
 	<ItemGroup>
-		<PackageReference Include="DuckDB.NET.Data.Full" Version="0.10.1" />
-		<PackageReference Include="DuckDB.NET.Data" Version="0.10.1" />
+		<PackageReference Include="DuckDB.NET.Data.Full" Version="1.0.0" />
+		<PackageReference Include="DuckDB.NET.Data" Version="1.0.0" />
 		<PackageReference Include="Microsoft.DotNet.Interactive" Version="1.0.0-beta.24164.1" />
 		<PackageReference Include="Microsoft.DotNet.Interactive.Formatting" Version="1.0.0-beta.24164.1" />
 	</ItemGroup>

--- a/src/ImageSharp.InteractiveExtension/ImageSharp.InteractiveExtension.csproj
+++ b/src/ImageSharp.InteractiveExtension/ImageSharp.InteractiveExtension.csproj
@@ -23,7 +23,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.DotNet.Interactive" Version="1.0.0-beta.24164.1" />
 		<PackageReference Include="Microsoft.DotNet.Interactive.Formatting" Version="1.0.0-beta.24164.1" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SandDance.InteractiveExtension.Tests/SandDance.InteractiveExtension.Tests.csproj
+++ b/src/SandDance.InteractiveExtension.Tests/SandDance.InteractiveExtension.Tests.csproj
@@ -12,7 +12,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.9.0" />
 		<PackageReference Include="Assent" Version="2.1.0" />
-		<PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
+		<PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 		<PackageReference Include="Microsoft.DotNet.Interactive" Version="1.0.0-beta.24164.1" />
 		<PackageReference Include="Microsoft.DotNet.Interactive.CSharp" Version="1.0.0-beta.24164.1" />

--- a/src/TestUtilities/TestUtilities.csproj
+++ b/src/TestUtilities/TestUtilities.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.9.0" />
-		<PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
+		<PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
 		<PackageReference Include="Microsoft.DotNet.Interactive" Version="1.0.0-beta.24164.1" />
 	</ItemGroup>
 


### PR DESCRIPTION
- Updated HtmlAgilityPack version from 1.11.46 to 1.11.61.
- Updated DuckDB.NET.Data.Full version from 0.10.1 to 1.0.0.
- Updated DuckDB.NET.Data version from 0.10.1 to 1.0.0.
- Updated SixLabors.ImageSharp version from 3.1.3 to 3.1.4.

These changes ensure that the code is using the latest versions of these packages for improved functionality and compatibility with other dependencies.

Note: This commit does not include any changes to specific files or code logic; it only updates package references in project files for better package management and maintenance purposes.
